### PR TITLE
Enable LINZ geodetic file to be imported via npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const linzGeodetic = require('./www/linz-geodetic');
+
+module.exports = {
+    LINZ: Object.assign({}, linzGeodetic)
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "nzmapconv",
+    "version": "1.0.0",
+    "description": "nzmapconv",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/tuatahi-fibre/nzmapconv.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+      "url": "https://github.com/tuatahi-fibre/nzmapconv/issues"
+    },
+    "homepage": "https://github.com/tuatahi-fibre/nzmapconv#readme"
+  }

--- a/www/linz-geodetic.js
+++ b/www/linz-geodetic.js
@@ -625,3 +625,5 @@ LINZ.Geodetic.Location.prototype.as=function( coordSysCode )
     }
     return this.coordinates[coordSysCode];
 }
+
+module.exports = LINZ;


### PR DESCRIPTION
This is a very basic change created by @raydenl which I am readying for use in our own code. 

Note: I purposefully do not pull in everything as we only require the one class, and Rayden has advised the extra classes may cause issues (and distract from our needs.)